### PR TITLE
ICSAAS-306 implement index update service

### DIFF
--- a/api/src/main/java/com/valtech/aem/saas/api/caconfig/SearchConfiguration.java
+++ b/api/src/main/java/com/valtech/aem/saas/api/caconfig/SearchConfiguration.java
@@ -10,6 +10,9 @@ public @interface SearchConfiguration {
   @Property(label = "Search Index", description = "SaaS index (Required)")
   String index() default StringUtils.EMPTY;
 
+  @Property(label = "Search Client", description = "SaaS client (Required)")
+  String client() default StringUtils.EMPTY;
+
   @Property(label = "Search Field Name - Values", description = "Base Filters (Optional)")
   SearchFilterConfiguration[] searchFilters() default {};
 

--- a/api/src/main/java/com/valtech/aem/saas/api/indexing/IndexContentPayload.java
+++ b/api/src/main/java/com/valtech/aem/saas/api/indexing/IndexContentPayload.java
@@ -1,0 +1,20 @@
+package com.valtech.aem.saas.api.indexing;
+
+import com.google.gson.JsonObject;
+
+/**
+ * An object representing the payload for indexing content requests.
+ */
+public interface IndexContentPayload {
+
+  String getContent();
+
+  String getTitle();
+
+  String getUrl();
+
+  String getRepositoryPath();
+
+  JsonObject getMetadata();
+
+}

--- a/api/src/main/java/com/valtech/aem/saas/api/indexing/IndexUpdateResponse.java
+++ b/api/src/main/java/com/valtech/aem/saas/api/indexing/IndexUpdateResponse.java
@@ -1,0 +1,15 @@
+package com.valtech.aem.saas.api.indexing;
+
+/**
+ * An object representing the response of an index update request.
+ */
+public interface IndexUpdateResponse {
+
+  String getMessage();
+
+  String getUrl();
+
+  String getSiteId();
+
+  String getId();
+}

--- a/api/src/main/java/com/valtech/aem/saas/api/indexing/IndexUpdateService.java
+++ b/api/src/main/java/com/valtech/aem/saas/api/indexing/IndexUpdateService.java
@@ -1,0 +1,42 @@
+package com.valtech.aem.saas.api.indexing;
+
+import java.util.Optional;
+import lombok.NonNull;
+
+/**
+ * Service for indexing content on SaaS admin.
+ */
+public interface IndexUpdateService {
+
+  /**
+   * Schedules an 'add index content' job to the indexing queue in saas admin.
+   *
+   * @param client         unique identifier assigned to a site in the saas admin tool.
+   * @param url            public url of the resource presenting the content that will be indexed.
+   * @param repositoryPath a regex matching the resource/content node's location in jcr.
+   * @return response optional, which is empty if the there has been an error during the request execution.
+   */
+  Optional<IndexUpdateResponse> indexUrl(@NonNull String client, @NonNull String url, @NonNull String repositoryPath);
+
+  /**
+   * Adds an 'delete index' job to the indexing queue in saas admin.
+   *
+   * @param client         unique identifier assigned to a site in the saas admin tool.
+   * @param url            public url of the resource presenting the content that will be removed from indexed data.
+   * @param repositoryPath a regex matching the resource/content node's location in jcr.
+   * @return response optional, which is empty if the there has been an error during the request execution.
+   */
+  Optional<IndexUpdateResponse> deleteIndexedUrl(@NonNull String client, @NonNull String url,
+      @NonNull String repositoryPath);
+
+  /**
+   * Adds an 'add index content' job to the indexing queue in saas admin.
+   *
+   * @param client              unique identifier assigned to a site in the saas admin tool.
+   * @param indexContentPayload a pojo that is used for creating a json payload with a predefined structure, that
+   *                            represents the content to be indexed.
+   * @return response optional, which is empty if the there has been an error during the request execution.
+   */
+  Optional<IndexUpdateResponse> indexContent(@NonNull String client, @NonNull IndexContentPayload indexContentPayload);
+
+}

--- a/core/src/main/java/com/valtech/aem/saas/core/http/client/DefaultSearchRequestExecutorService.java
+++ b/core/src/main/java/com/valtech/aem/saas/core/http/client/DefaultSearchRequestExecutorService.java
@@ -8,10 +8,10 @@ import java.security.KeyManagementException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Optional;
-import javax.servlet.http.HttpServletResponse;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
+import org.apache.http.HttpResponse;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CredentialsProvider;
@@ -47,21 +47,22 @@ public class DefaultSearchRequestExecutorService implements SearchRequestExecuto
     HttpUriRequest request = searchRequest.getRequest();
     CloseableHttpClient httpClient = httpClientBuilder.build();
     CloseableHttpResponse response = null;
-    SearchResponse searchResponse = null;
     try {
       response = httpClient.execute(request);
       log.info("Executing {} request on search api {}", request.getMethod(), request.getURI());
+      log.info("Success status codes: {}", searchRequest.getSuccessStatusCodes());
       log.info("Status Code: {}", response.getStatusLine().getStatusCode());
       log.debug("Reason: {}", response.getStatusLine().getReasonPhrase());
-      if (HttpServletResponse.SC_OK == response.getStatusLine().getStatusCode()) {
+      boolean isSuccess = isRequestSuccessful(searchRequest, response);
+      if (isSuccess) {
         HttpResponseParser httpResponseParser = new HttpResponseParser(response);
         if (log.isDebugEnabled()) {
           log.debug("Response content: {}", httpResponseParser.getContentString());
         }
-        JsonObject jsonResponse = new HttpResponseParser(response).toGsonModel(JsonObject.class);
-        if (jsonResponse != null) {
-          searchResponse = new SearchResponse(jsonResponse);
-        }
+      }
+      JsonObject jsonResponse = new HttpResponseParser(response).toGsonModel(JsonObject.class);
+      if (jsonResponse != null) {
+        return Optional.of(new SearchResponse(jsonResponse, isSuccess));
       }
     } catch (IOException e) {
       log.error("Error while executing request", e);
@@ -71,7 +72,17 @@ public class DefaultSearchRequestExecutorService implements SearchRequestExecuto
         IOUtils.closeQuietly(httpClient, e -> log.error("Could not close client.", e));
       }
     }
-    return Optional.ofNullable(searchResponse);
+    return Optional.empty();
+  }
+
+  private boolean isRequestSuccessful(SearchRequest searchRequest, HttpResponse httpResponse) {
+    boolean success = searchRequest.getSuccessStatusCodes().contains(httpResponse.getStatusLine().getStatusCode());
+    if (success) {
+      log.debug("Request is successful.");
+    } else {
+      log.debug("Request has failed.");
+    }
+    return success;
   }
 
   @Activate

--- a/core/src/main/java/com/valtech/aem/saas/core/http/client/SearchRequestExecutorService.java
+++ b/core/src/main/java/com/valtech/aem/saas/core/http/client/SearchRequestExecutorService.java
@@ -14,7 +14,7 @@ public interface SearchRequestExecutorService {
    * Returns the response from SaaS.
    *
    * @param searchRequest http request.
-   * @return optional SearchResponse object.
+   * @return SearchResponse optional, which is empty if an error/exception occured during request execution.
    */
   Optional<SearchResponse> execute(@NonNull SearchRequest searchRequest);
 

--- a/core/src/main/java/com/valtech/aem/saas/core/http/request/HttpDeleteWithBody.java
+++ b/core/src/main/java/com/valtech/aem/saas/core/http/request/HttpDeleteWithBody.java
@@ -1,0 +1,26 @@
+package com.valtech.aem.saas.core.http.request;
+
+import java.net.URI;
+import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
+
+/**
+ * Custom Http Delete implementation that supports request body.
+ */
+class HttpDeleteWithBody extends HttpEntityEnclosingRequestBase {
+
+  public HttpDeleteWithBody() {
+  }
+
+  public HttpDeleteWithBody(final URI uri) {
+    this.setURI(uri);
+  }
+
+  public HttpDeleteWithBody(final String uri) {
+    this(URI.create(uri));
+  }
+
+  public String getMethod() {
+    return HttpDelete.METHOD_NAME;
+  }
+}

--- a/core/src/main/java/com/valtech/aem/saas/core/http/request/SearchRequest.java
+++ b/core/src/main/java/com/valtech/aem/saas/core/http/request/SearchRequest.java
@@ -1,5 +1,6 @@
 package com.valtech.aem.saas.core.http.request;
 
+import java.util.List;
 import org.apache.http.client.methods.HttpUriRequest;
 
 /**
@@ -13,4 +14,11 @@ public interface SearchRequest {
    * @return http request.
    */
   HttpUriRequest getRequest();
+
+  /**
+   * Gets a list of http resoponse status codes that will be considered as response success
+   *
+   * @return list of integers.
+   */
+  List<Integer> getSuccessStatusCodes();
 }

--- a/core/src/main/java/com/valtech/aem/saas/core/http/request/SearchRequestDelete.java
+++ b/core/src/main/java/com/valtech/aem/saas/core/http/request/SearchRequestDelete.java
@@ -3,27 +3,35 @@ package com.valtech.aem.saas.core.http.request;
 import java.util.Collections;
 import java.util.List;
 import javax.servlet.http.HttpServletResponse;
+import lombok.Builder;
 import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.http.client.methods.HttpGet;
+import org.apache.http.HttpEntity;
 import org.apache.http.client.methods.HttpUriRequest;
 
 /**
- * Represents a GET search request. It requires the request uri, including the query string.
+ * Represents a DELETE search request with request body. It requires the request uri and the payload in form of {@link
+ * HttpEntity}.
  */
-@RequiredArgsConstructor
-public class SearchRequestGet implements SearchRequest {
+@Slf4j
+@Builder
+public class SearchRequestDelete implements SearchRequest {
 
   @NonNull
   private final String uri;
+  private final HttpEntity httpEntity;
 
   @Override
   public HttpUriRequest getRequest() {
     if (StringUtils.isBlank(uri)) {
       throw new IllegalArgumentException("Request uri must not be blank.");
     }
-    return new HttpGet(uri);
+    HttpDeleteWithBody httpDelete = new HttpDeleteWithBody(uri);
+    if (httpEntity != null) {
+      httpDelete.setEntity(httpEntity);
+    }
+    return httpDelete;
   }
 
   @Override

--- a/core/src/main/java/com/valtech/aem/saas/core/http/response/DefaultIndexUpdateDataExtractionStrategy.java
+++ b/core/src/main/java/com/valtech/aem/saas/core/http/response/DefaultIndexUpdateDataExtractionStrategy.java
@@ -1,0 +1,24 @@
+package com.valtech.aem.saas.core.http.response;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.valtech.aem.saas.api.indexing.IndexUpdateResponse;
+import java.util.Optional;
+
+/**
+ * A strategy for extracting index update response data.
+ */
+public class DefaultIndexUpdateDataExtractionStrategy implements
+    SearchResponseDataExtractionStrategy<IndexUpdateResponse> {
+
+  @Override
+  public String propertyName() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Optional<IndexUpdateResponse> getData(JsonObject response) {
+    return Optional.ofNullable(response)
+        .map(jsonObject -> new Gson().fromJson(jsonObject, DefaultIndexUpdateResponse.class));
+  }
+}

--- a/core/src/main/java/com/valtech/aem/saas/core/http/response/DefaultIndexUpdateResponse.java
+++ b/core/src/main/java/com/valtech/aem/saas/core/http/response/DefaultIndexUpdateResponse.java
@@ -1,0 +1,22 @@
+package com.valtech.aem.saas.core.http.response;
+
+import com.google.gson.annotations.SerializedName;
+import com.valtech.aem.saas.api.indexing.IndexUpdateResponse;
+import lombok.Value;
+
+/**
+ * Default implementation of {@link IndexUpdateResponse} interface. The POJO is used for serializing response of index
+ * update api.
+ */
+@Value
+public class DefaultIndexUpdateResponse implements IndexUpdateResponse {
+
+  String message;
+
+  String url;
+
+  @SerializedName("site.id")
+  String siteId;
+
+  String id;
+}

--- a/core/src/main/java/com/valtech/aem/saas/core/http/response/SearchResponse.java
+++ b/core/src/main/java/com/valtech/aem/saas/core/http/response/SearchResponse.java
@@ -2,17 +2,18 @@ package com.valtech.aem.saas.core.http.response;
 
 import com.google.gson.JsonObject;
 import java.util.Optional;
-import lombok.NonNull;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public class SearchResponse {
 
-  @NonNull
   private final JsonObject response;
+  @Getter
+  private final boolean success;
 
   public <T> Optional<T> get(SearchResponseDataExtractionStrategy<T> strategy) {
-    return strategy.getData(response);
+    return Optional.ofNullable(response).flatMap(strategy::getData);
   }
 
 }

--- a/core/src/main/java/com/valtech/aem/saas/core/indexing/DefaultIndexContentPayload.java
+++ b/core/src/main/java/com/valtech/aem/saas/core/indexing/DefaultIndexContentPayload.java
@@ -1,0 +1,141 @@
+package com.valtech.aem.saas.core.indexing;
+
+import com.google.gson.JsonObject;
+import com.google.gson.annotations.SerializedName;
+import com.valtech.aem.saas.api.indexing.IndexContentPayload;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Value;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Default implementation of the {@link IndexContentPayload} interface. It employs the builder pattern for object
+ * creation and it performs an object validation when building the object.
+ */
+@Value
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class DefaultIndexContentPayload implements IndexContentPayload {
+
+  String content;
+
+  String title;
+
+  String url;
+
+  @SerializedName("repository_path")
+  String repositoryPath;
+
+  JsonObject metadata;
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+
+    public static final String PN_LANGUAGE = "language";
+    public static final String PN_META_KEYWORDS = "meta_keywords";
+    public static final String PN_META_DESCRIPTION = "meta_description";
+    public static final String PN_SCOPE = "scope";
+
+    private String content;
+    private String title;
+    private String url;
+    private String repositoryPath;
+    private String language;
+    private String metaKeywords;
+    private String metaDescription;
+    private String scope;
+    private Map<String, String> optionalMetaProperties;
+
+    Builder() {
+    }
+
+    public Builder content(String content) {
+      this.content = content;
+      return this;
+    }
+
+    public Builder title(String title) {
+      this.title = title;
+      return this;
+    }
+
+    public Builder url(String url) {
+      this.url = url;
+      return this;
+    }
+
+    public Builder repositoryPath(String repositoryPath) {
+      this.repositoryPath = repositoryPath;
+      return this;
+    }
+
+    public Builder language(String language) {
+      this.language = language;
+      return this;
+    }
+
+    public Builder metaKeywords(String metaKeywords) {
+      this.metaKeywords = metaKeywords;
+      return this;
+    }
+
+    public Builder metaDescription(String metaDescription) {
+      this.metaDescription = metaDescription;
+      return this;
+    }
+
+    public Builder scope(String scope) {
+      this.scope = scope;
+      return this;
+    }
+
+    public Builder optionalMetaProperty(String name, String value) {
+      if (this.optionalMetaProperties == null) {
+        this.optionalMetaProperties = new HashMap<>();
+      }
+      this.optionalMetaProperties.put(name, value);
+      return this;
+    }
+
+    public Builder optionalMetaProperties(Map<String, String> properties) {
+      if (this.optionalMetaProperties == null) {
+        this.optionalMetaProperties = new HashMap<>();
+      }
+      this.optionalMetaProperties.putAll(properties);
+      return this;
+    }
+
+    public Builder clearOptionalMetaProperties() {
+      if (this.optionalMetaProperties != null) {
+        this.optionalMetaProperties.clear();
+      }
+      return this;
+    }
+
+    public DefaultIndexContentPayload build() {
+      if (!isValid()) {
+        throw new IllegalStateException("Please set value for all required fields.");
+      }
+      JsonObject metadata = new JsonObject();
+      metadata.addProperty(PN_LANGUAGE, language);
+      metadata.addProperty(PN_META_KEYWORDS, metaKeywords);
+      metadata.addProperty(PN_META_DESCRIPTION, metaDescription);
+      metadata.addProperty(PN_SCOPE, scope);
+      Optional.ofNullable(optionalMetaProperties).orElse(Collections.emptyMap()).forEach(metadata::addProperty);
+      return new DefaultIndexContentPayload(content, title, url, repositoryPath, metadata);
+    }
+
+    private boolean isValid() {
+      return StringUtils.isNoneBlank(content, title, url, repositoryPath, language, metaKeywords, metaDescription,
+          scope);
+    }
+  }
+
+
+}

--- a/core/src/main/java/com/valtech/aem/saas/core/indexing/DefaultIndexUpdateService.java
+++ b/core/src/main/java/com/valtech/aem/saas/core/indexing/DefaultIndexUpdateService.java
@@ -1,0 +1,154 @@
+package com.valtech.aem.saas.core.indexing;
+
+import com.google.gson.Gson;
+import com.valtech.aem.saas.api.indexing.IndexContentPayload;
+import com.valtech.aem.saas.api.indexing.IndexUpdateResponse;
+import com.valtech.aem.saas.api.indexing.IndexUpdateService;
+import com.valtech.aem.saas.core.http.client.SearchRequestExecutorService;
+import com.valtech.aem.saas.core.http.client.SearchServiceConnectionConfigurationService;
+import com.valtech.aem.saas.core.http.request.SearchRequest;
+import com.valtech.aem.saas.core.http.request.SearchRequestDelete;
+import com.valtech.aem.saas.core.http.request.SearchRequestPost;
+import com.valtech.aem.saas.core.http.response.DefaultIndexUpdateDataExtractionStrategy;
+import com.valtech.aem.saas.core.indexing.DefaultIndexUpdateService.Configuration;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.client.entity.EntityBuilder;
+import org.apache.http.entity.ContentType;
+import org.apache.http.message.BasicNameValuePair;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Modified;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.metatype.annotations.AttributeDefinition;
+import org.osgi.service.metatype.annotations.AttributeType;
+import org.osgi.service.metatype.annotations.Designate;
+import org.osgi.service.metatype.annotations.ObjectClassDefinition;
+
+@Slf4j
+@Component(name = "Search as a Service - Index Update Service",
+    service = IndexUpdateService.class)
+@Designate(ocd = Configuration.class)
+public class DefaultIndexUpdateService implements IndexUpdateService {
+
+  public static final String REQUEST_PARAMETER_URL = "url";
+  public static final String REQUEST_PARAMETER_REPOSITORY_PATH = "repository_path";
+
+  @Reference
+  private SearchRequestExecutorService searchRequestExecutorService;
+
+  @Reference
+  private SearchServiceConnectionConfigurationService searchServiceConnectionConfigurationService;
+
+  private Configuration configuration;
+
+  @Activate
+  @Modified
+  private void activate(Configuration configuration) {
+    this.configuration = configuration;
+  }
+
+  @Override
+  public Optional<IndexUpdateResponse> indexUrl(@NonNull String client, @NonNull String url,
+      @NonNull String repositoryPath) {
+    validateInput(client, url, repositoryPath);
+
+    SearchRequest searchRequest = SearchRequestPost.builder()
+        .uri(getRequestUri(client, configuration.indexUpdateService_apiIndexTriggerAction()))
+        .httpEntity(EntityBuilder.create().setParameters(new BasicNameValuePair(REQUEST_PARAMETER_URL, url),
+                new BasicNameValuePair(REQUEST_PARAMETER_REPOSITORY_PATH, repositoryPath))
+            .setContentEncoding(StandardCharsets.UTF_8.name())
+            .build())
+        .build();
+
+    return searchRequestExecutorService.execute(searchRequest)
+        .flatMap(response -> response.get(new DefaultIndexUpdateDataExtractionStrategy()));
+  }
+
+  @Override
+  public Optional<IndexUpdateResponse> deleteIndexedUrl(@NonNull String client, @NonNull String url,
+      @NonNull String repositoryPath) {
+    validateInput(client, url, repositoryPath);
+    SearchRequest searchRequest = SearchRequestDelete.builder()
+        .uri(getRequestUri(client, configuration.indexUpdateService_apiIndexTriggerAction()))
+        .httpEntity(EntityBuilder.create().setParameters(new BasicNameValuePair(REQUEST_PARAMETER_URL, url),
+                new BasicNameValuePair(REQUEST_PARAMETER_REPOSITORY_PATH, repositoryPath))
+            .setContentEncoding(StandardCharsets.UTF_8.name())
+            .build())
+        .build();
+    return searchRequestExecutorService.execute(searchRequest)
+        .flatMap(response -> response.get(new DefaultIndexUpdateDataExtractionStrategy()));
+  }
+
+  @Override
+  public Optional<IndexUpdateResponse> indexContent(@NonNull String client,
+      @NonNull IndexContentPayload indexContentPayload) {
+    validateInputClient(client);
+    SearchRequest searchRequest = SearchRequestPost.builder()
+        .uri(getRequestUri(client, configuration.indexUpdateService_apiPushContentAction()))
+        .httpEntity(EntityBuilder.create().setText(new Gson().toJson(indexContentPayload))
+            .setContentType(ContentType.APPLICATION_JSON)
+            .setContentEncoding(StandardCharsets.UTF_8.name())
+            .build())
+        .build();
+
+    return searchRequestExecutorService.execute(searchRequest)
+        .flatMap(response -> response.get(new DefaultIndexUpdateDataExtractionStrategy()));
+  }
+
+  private String getRequestUri(String client, String action) {
+    return String.format("%s%s%s%s%s", searchServiceConnectionConfigurationService.getBaseUrl(),
+        configuration.indexUpdateService_apiBasePath(), client,
+        configuration.indexUpdateService_apiVersionPath(), action);
+  }
+
+  private void validateInput(String client, String url, String repositoryPath) {
+    validateInputClient(client);
+    if (StringUtils.isBlank(url)) {
+      throw new IllegalArgumentException("Please pass a url of a content that should be indexed.");
+    }
+    if (StringUtils.isBlank(repositoryPath)) {
+      throw new IllegalArgumentException("Please pass a repository path regex value.");
+    }
+  }
+
+  private void validateInputClient(String client) {
+    if (StringUtils.isBlank(client)) {
+      throw new IllegalArgumentException("Please configure client in context aware configuration.");
+    }
+  }
+
+  @ObjectClassDefinition(name = "Search as a Service - Index Update Service Configuration",
+      description = "Index Update Api specific details.")
+  public @interface Configuration {
+
+    String DEFAULT_API_INDEX_TRIGGER_ACTION = "/index/trigger";
+    String DEFAULT_API_PUSH_CONTENT_ACTION = "/content";
+    String DEFAULT_API_BASE_PATH = "/admin";
+    String DEFAULT_API_VERSION_PATH = "/api/v3";
+
+    @AttributeDefinition(name = "Api base path",
+        description = "Api base path",
+        type = AttributeType.STRING)
+    String indexUpdateService_apiBasePath() default DEFAULT_API_BASE_PATH;
+
+    @AttributeDefinition(name = "Api version path",
+        description = "Api base path",
+        type = AttributeType.STRING)
+    String indexUpdateService_apiVersionPath() default DEFAULT_API_VERSION_PATH;
+
+    @AttributeDefinition(name = "Api index trigger action",
+        description = "What kind of action should be defined",
+        type = AttributeType.STRING)
+    String indexUpdateService_apiIndexTriggerAction() default DEFAULT_API_INDEX_TRIGGER_ACTION;
+
+    @AttributeDefinition(name = "Api action",
+        description = "What kind of action should be defined",
+        type = AttributeType.STRING)
+    String indexUpdateService_apiPushContentAction() default DEFAULT_API_PUSH_CONTENT_ACTION;
+
+  }
+}

--- a/core/src/test/java/com/valtech/aem/saas/core/fulltextsearch/DefaultFulltextSearchServiceTest.java
+++ b/core/src/test/java/com/valtech/aem/saas/core/fulltextsearch/DefaultFulltextSearchServiceTest.java
@@ -59,7 +59,7 @@ class DefaultFulltextSearchServiceTest {
   @Test
   void testGetResults_responseBodyMissing() {
     when(searchRequestExecutorService.execute(any(SearchRequest.class))).thenReturn(
-        Optional.of(new SearchResponse(new JsonObject())));
+        Optional.of(new SearchResponse(new JsonObject(), true)));
     FulltextSearchGetRequestPayload payload = DefaultFulltextSearchRequestPayload.builder(
         new DefaultTermQuery("bar"), new DefaultLanguageQuery("de")).build();
     MatcherAssert.assertThat(testee.getResults("foo", payload).isPresent(), is(false));
@@ -70,7 +70,7 @@ class DefaultFulltextSearchServiceTest {
     when(searchRequestExecutorService.execute(any(SearchRequest.class))).thenReturn(
         Optional.of(new SearchResponse(new JsonParser().parse(
                 new InputStreamReader(getClass().getResourceAsStream("/__files/search/fulltext/response.json")))
-            .getAsJsonObject())));
+            .getAsJsonObject(), true)));
     FulltextSearchGetRequestPayload payload = DefaultFulltextSearchRequestPayload.builder(
         new DefaultTermQuery("bar"), new DefaultLanguageQuery("de")).build();
     MatcherAssert.assertThat(testee.getResults("foo", payload).isPresent(), is(true));

--- a/core/src/test/java/com/valtech/aem/saas/core/fulltextsearch/DefaultFulltextSearchServiceTest.java
+++ b/core/src/test/java/com/valtech/aem/saas/core/fulltextsearch/DefaultFulltextSearchServiceTest.java
@@ -1,5 +1,6 @@
 package com.valtech.aem.saas.core.fulltextsearch;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.any;
@@ -8,17 +9,16 @@ import static org.mockito.Mockito.when;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.valtech.aem.saas.api.fulltextsearch.FulltextSearchGetRequestPayload;
-import com.valtech.aem.saas.core.query.DefaultLanguageQuery;
-import com.valtech.aem.saas.core.query.DefaultTermQuery;
+import com.valtech.aem.saas.core.http.client.DefaultSearchServiceConnectionConfigurationService;
 import com.valtech.aem.saas.core.http.client.SearchRequestExecutorService;
 import com.valtech.aem.saas.core.http.request.SearchRequest;
 import com.valtech.aem.saas.core.http.response.SearchResponse;
-import com.valtech.aem.saas.core.http.client.DefaultSearchServiceConnectionConfigurationService;
+import com.valtech.aem.saas.core.query.DefaultLanguageQuery;
+import com.valtech.aem.saas.core.query.DefaultTermQuery;
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 import java.io.InputStreamReader;
 import java.util.Optional;
-import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -53,7 +53,7 @@ class DefaultFulltextSearchServiceTest {
     when(searchRequestExecutorService.execute(any(SearchRequest.class))).thenReturn(Optional.empty());
     FulltextSearchGetRequestPayload payload = DefaultFulltextSearchRequestPayload.builder(
         new DefaultTermQuery("bar"), new DefaultLanguageQuery("de")).build();
-    MatcherAssert.assertThat(testee.getResults("foo", payload).isPresent(), is(false));
+    assertThat(testee.getResults("foo", payload).isPresent(), is(false));
   }
 
   @Test
@@ -62,7 +62,7 @@ class DefaultFulltextSearchServiceTest {
         Optional.of(new SearchResponse(new JsonObject(), true)));
     FulltextSearchGetRequestPayload payload = DefaultFulltextSearchRequestPayload.builder(
         new DefaultTermQuery("bar"), new DefaultLanguageQuery("de")).build();
-    MatcherAssert.assertThat(testee.getResults("foo", payload).isPresent(), is(false));
+    assertThat(testee.getResults("foo", payload).isPresent(), is(false));
   }
 
   @Test
@@ -73,6 +73,6 @@ class DefaultFulltextSearchServiceTest {
             .getAsJsonObject(), true)));
     FulltextSearchGetRequestPayload payload = DefaultFulltextSearchRequestPayload.builder(
         new DefaultTermQuery("bar"), new DefaultLanguageQuery("de")).build();
-    MatcherAssert.assertThat(testee.getResults("foo", payload).isPresent(), is(true));
+    assertThat(testee.getResults("foo", payload).isPresent(), is(true));
   }
 }

--- a/core/src/test/java/com/valtech/aem/saas/core/http/request/SearchRequestDeleteTest.java
+++ b/core/src/test/java/com/valtech/aem/saas/core/http/request/SearchRequestDeleteTest.java
@@ -1,0 +1,39 @@
+package com.valtech.aem.saas.core.http.request;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+import javax.servlet.http.HttpServletResponse;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.hamcrest.core.IsInstanceOf;
+import org.junit.jupiter.api.Test;
+
+class SearchRequestDeleteTest {
+
+  @Test
+  void testBuilder() {
+    SearchRequestDelete.SearchRequestDeleteBuilder builder = SearchRequestDelete.builder();
+    assertThrows(NullPointerException.class, builder::build);
+  }
+
+  @Test
+  void getRequest() {
+    SearchRequestDelete emptySearchRequestDelete = SearchRequestDelete.builder().uri("").build();
+    assertThrows(IllegalArgumentException.class, emptySearchRequestDelete::getRequest);
+    SearchRequestDelete incorrectUriSyntaxSearchRequestDelete = SearchRequestDelete.builder().uri("$%^&*").build();
+    assertThrows(IllegalArgumentException.class, incorrectUriSyntaxSearchRequestDelete::getRequest);
+    assertThat(SearchRequestDelete.builder().uri("https://wknd.site/us/en/adventures/bali-surf-camp.html").build()
+        .getRequest(), IsInstanceOf.instanceOf(
+        HttpUriRequest.class));
+  }
+
+  @Test
+  void getSuccessStatusCodes() {
+    List<Integer> statusCodes = SearchRequestDelete.builder().uri("").build().getSuccessStatusCodes();
+    assertThat(statusCodes.size(), is(1));
+    assertThat(statusCodes.get(0), is(
+        HttpServletResponse.SC_OK));
+  }
+}

--- a/core/src/test/java/com/valtech/aem/saas/core/http/request/SearchRequestGetTest.java
+++ b/core/src/test/java/com/valtech/aem/saas/core/http/request/SearchRequestGetTest.java
@@ -1,0 +1,38 @@
+package com.valtech.aem.saas.core.http.request;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+import javax.servlet.http.HttpServletResponse;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.hamcrest.core.IsInstanceOf;
+import org.junit.jupiter.api.Test;
+
+class SearchRequestGetTest {
+
+  @Test
+  void testConstructor() {
+    assertThrows(NullPointerException.class, () -> new SearchRequestGet(null));
+  }
+
+  @Test
+  void getRequest() {
+    SearchRequestGet emptySearchRequestGet = new SearchRequestGet("");
+    assertThrows(IllegalArgumentException.class, emptySearchRequestGet::getRequest);
+    SearchRequestGet incorrectUriSyntaxSearchRequestGet = new SearchRequestGet("$%^&*");
+    assertThrows(IllegalArgumentException.class, incorrectUriSyntaxSearchRequestGet::getRequest);
+    assertThat(new SearchRequestGet("https://wknd.site/us/en/adventures/bali-surf-camp.html").getRequest(),
+        IsInstanceOf.instanceOf(
+            HttpUriRequest.class));
+  }
+
+  @Test
+  void getSuccessStatusCodes() {
+    List<Integer> statusCodes = new SearchRequestGet("").getSuccessStatusCodes();
+    assertThat(statusCodes.size(), is(1));
+    assertThat(statusCodes.get(0), is(
+        HttpServletResponse.SC_OK));
+  }
+}

--- a/core/src/test/java/com/valtech/aem/saas/core/http/request/SearchRequestPostTest.java
+++ b/core/src/test/java/com/valtech/aem/saas/core/http/request/SearchRequestPostTest.java
@@ -1,0 +1,43 @@
+package com.valtech.aem.saas.core.http.request;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+import javax.servlet.http.HttpServletResponse;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.hamcrest.core.IsInstanceOf;
+import org.junit.jupiter.api.Test;
+
+class SearchRequestPostTest {
+
+  @Test
+  void testBuilder() {
+    SearchRequestPost.SearchRequestPostBuilder builder = SearchRequestPost.builder();
+    assertThrows(NullPointerException.class, builder::build);
+  }
+
+  @Test
+  void getRequest() {
+    SearchRequestPost emptySearchRequestPost = SearchRequestPost.builder().uri("").build();
+    assertThrows(IllegalArgumentException.class, emptySearchRequestPost::getRequest);
+    SearchRequestPost incorrectUriSyntaxSearchRequestPost = SearchRequestPost.builder().uri("$%^&*").build();
+    assertThrows(IllegalArgumentException.class, incorrectUriSyntaxSearchRequestPost::getRequest);
+    assertThat(
+        SearchRequestPost.builder().uri("https://wknd.site/us/en/adventures/bali-surf-camp.html").build().getRequest(),
+        IsInstanceOf.instanceOf(
+            HttpUriRequest.class));
+  }
+
+  @Test
+  void getSuccessStatusCodes() {
+    List<Integer> statusCodes = SearchRequestPost.builder().uri("").build().getSuccessStatusCodes();
+    assertThat(statusCodes.size(), is(2));
+    assertThat(statusCodes.get(0), is(
+        HttpServletResponse.SC_OK));
+    assertThat(statusCodes.get(1), is(
+        HttpServletResponse.SC_CREATED));
+  }
+
+}

--- a/core/src/test/java/com/valtech/aem/saas/core/http/response/DefaultIndexUpdateDataExtractionStrategyTest.java
+++ b/core/src/test/java/com/valtech/aem/saas/core/http/response/DefaultIndexUpdateDataExtractionStrategyTest.java
@@ -1,0 +1,29 @@
+package com.valtech.aem.saas.core.http.response;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.valtech.aem.saas.api.indexing.IndexUpdateResponse;
+import java.io.InputStreamReader;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class DefaultIndexUpdateDataExtractionStrategyTest {
+
+  @Test
+  void getResponse() {
+    DefaultIndexUpdateDataExtractionStrategy strategy = new DefaultIndexUpdateDataExtractionStrategy();
+    Assertions.assertThrows(UnsupportedOperationException.class, strategy::propertyName);
+    assertThat(strategy.getData(new JsonObject()).isPresent(), is(true));
+    assertThat(strategy.getData(new JsonParser().parse(
+            new InputStreamReader(getClass().getResourceAsStream("/__files/search/indexupdate/success.json")))
+        .getAsJsonObject()).isPresent(), is(true));
+    assertThat(strategy.getData(new JsonParser().parse(
+            new InputStreamReader(getClass().getResourceAsStream("/__files/search/indexupdate/success.json")))
+        .getAsJsonObject()).get(), instanceOf(IndexUpdateResponse.class));
+  }
+}

--- a/core/src/test/java/com/valtech/aem/saas/core/indexing/DefaultIndexContentPayloadTest.java
+++ b/core/src/test/java/com/valtech/aem/saas/core/indexing/DefaultIndexContentPayloadTest.java
@@ -1,0 +1,26 @@
+package com.valtech.aem.saas.core.indexing;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsInstanceOf;
+import org.junit.jupiter.api.Test;
+
+class DefaultIndexContentPayloadTest {
+
+  @Test
+  void testIndexContentPayloadBuild() {
+    DefaultIndexContentPayload.Builder builder = DefaultIndexContentPayload.builder();
+    assertThrows(IllegalStateException.class, builder::build);
+    MatcherAssert.assertThat(builder
+        .content("foo")
+        .title("bar")
+        .url("baz")
+        .repositoryPath("baz")
+        .language("de")
+        .metaKeywords("foo bar")
+        .metaDescription("bar")
+        .scope("qux")
+        .build(), IsInstanceOf.instanceOf(DefaultIndexContentPayload.class));
+  }
+}

--- a/core/src/test/java/com/valtech/aem/saas/core/indexing/DefaultIndexContentPayloadTest.java
+++ b/core/src/test/java/com/valtech/aem/saas/core/indexing/DefaultIndexContentPayloadTest.java
@@ -1,8 +1,8 @@
 package com.valtech.aem.saas.core.indexing;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsInstanceOf;
 import org.junit.jupiter.api.Test;
 
@@ -12,7 +12,7 @@ class DefaultIndexContentPayloadTest {
   void testIndexContentPayloadBuild() {
     DefaultIndexContentPayload.Builder builder = DefaultIndexContentPayload.builder();
     assertThrows(IllegalStateException.class, builder::build);
-    MatcherAssert.assertThat(builder
+    assertThat(builder
         .content("foo")
         .title("bar")
         .url("baz")

--- a/core/src/test/java/com/valtech/aem/saas/core/indexing/DefaultIndexUpdateServiceTest.java
+++ b/core/src/test/java/com/valtech/aem/saas/core/indexing/DefaultIndexUpdateServiceTest.java
@@ -1,0 +1,155 @@
+package com.valtech.aem.saas.core.indexing;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.when;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.valtech.aem.saas.api.indexing.IndexUpdateResponse;
+import com.valtech.aem.saas.api.indexing.IndexUpdateService;
+import com.valtech.aem.saas.core.http.client.DefaultSearchServiceConnectionConfigurationService;
+import com.valtech.aem.saas.core.http.client.SearchRequestExecutorService;
+import com.valtech.aem.saas.core.http.request.SearchRequest;
+import com.valtech.aem.saas.core.http.response.SearchResponse;
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+import java.io.InputStreamReader;
+import java.util.Optional;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith({AemContextExtension.class, MockitoExtension.class})
+class DefaultIndexUpdateServiceTest {
+
+  public static final String SAMPLE_URL = "https://wknd.site/us/en/adventures/bali-surf-camp.html";
+  public static final String SAMPLE_REPO_PATH = "/content/wknd/(?!www)";
+  @Mock
+  SearchRequestExecutorService searchRequestExecutorService;
+
+  IndexUpdateService testee;
+
+  @BeforeEach
+  void setUp(AemContext context) {
+    context.registerInjectActivateService(new DefaultSearchServiceConnectionConfigurationService());
+    context.registerService(SearchRequestExecutorService.class, searchRequestExecutorService);
+    testee = context.registerInjectActivateService(new DefaultIndexUpdateService());
+  }
+
+  @Test
+  void testIndexUrl() {
+    when(searchRequestExecutorService.execute(any(SearchRequest.class)))
+        .thenReturn(Optional.of(new SearchResponse(getSuccessResponse(), true)));
+    Optional<IndexUpdateResponse> response = testee.indexUrl("/foo", SAMPLE_URL, SAMPLE_REPO_PATH);
+    assertThat(response.isPresent(), is(true));
+    testSuccessfulResponse(response.get());
+  }
+
+  @Test
+  void testIndexUrl_exceptionDuringExecution() {
+    when(searchRequestExecutorService.execute(any(SearchRequest.class)))
+        .thenReturn(Optional.empty());
+    Optional<IndexUpdateResponse> response = testee.indexUrl("/foo", SAMPLE_URL, SAMPLE_REPO_PATH);
+    assertThat(response.isPresent(), is(false));
+  }
+
+  @Test
+  void testIndexUrl_inputValidationFails() {
+    assertThrows(NullPointerException.class,
+        () -> testee.indexUrl(null, SAMPLE_URL, SAMPLE_REPO_PATH));
+    assertThrows(IllegalArgumentException.class,
+        () -> testee.indexUrl("/foo", StringUtils.EMPTY, SAMPLE_REPO_PATH));
+    assertThrows(NullPointerException.class,
+        () -> testee.indexUrl("/foo", SAMPLE_URL, null));
+  }
+
+  @Test
+  void testIndexContent() {
+    when(searchRequestExecutorService.execute(any(SearchRequest.class)))
+        .thenReturn(Optional.of(new SearchResponse(getSuccessResponse(), true)));
+    DefaultIndexContentPayload defaultIndexContentPayload = getCompleteDefaultIndexContentPayload();
+    Optional<IndexUpdateResponse> response = testee.indexContent("/foo", defaultIndexContentPayload);
+    assertThat(response.isPresent(), is(true));
+    testSuccessfulResponse(response.get());
+  }
+
+  @Test
+  void testIndexContent_inputValidationFails() {
+    assertThrows(NullPointerException.class, () -> testee.indexContent(null, null));
+    DefaultIndexContentPayload defaultIndexContentPayload = getCompleteDefaultIndexContentPayload();
+    assertThrows(IllegalArgumentException.class,
+        () -> testee.indexContent(StringUtils.EMPTY, defaultIndexContentPayload));
+  }
+
+  @Test
+  void testIndexContent_exceptionDuringExecution() {
+    when(searchRequestExecutorService.execute(any(SearchRequest.class)))
+        .thenReturn(Optional.empty());
+    Optional<IndexUpdateResponse> response = testee.indexContent("/foo", getCompleteDefaultIndexContentPayload());
+    assertThat(response.isPresent(), is(false));
+  }
+
+  @Test
+  void testDeleteIndexedUrl() {
+    when(searchRequestExecutorService.execute(any(SearchRequest.class)))
+        .thenReturn(Optional.of(new SearchResponse(getSuccessResponse(), true)));
+    Optional<IndexUpdateResponse> response = testee.deleteIndexedUrl("/foo", SAMPLE_URL, SAMPLE_REPO_PATH);
+    assertThat(response.isPresent(), is(true));
+    testSuccessfulResponse(response.get());
+  }
+
+  @Test
+  void testDeleteIndexedUrl_exceptionDuringExecution() {
+    when(searchRequestExecutorService.execute(any(SearchRequest.class)))
+        .thenReturn(Optional.empty());
+    Optional<IndexUpdateResponse> response = testee.deleteIndexedUrl("/foo", SAMPLE_URL, SAMPLE_REPO_PATH);
+    assertThat(response.isPresent(), is(false));
+  }
+
+
+  @Test
+  void testDeleteIndexedUrl_inputValidationFails() {
+    assertThrows(NullPointerException.class,
+        () -> testee.deleteIndexedUrl(null, SAMPLE_URL,
+            SAMPLE_REPO_PATH));
+    assertThrows(IllegalArgumentException.class,
+        () -> testee.deleteIndexedUrl("/foo", StringUtils.EMPTY, SAMPLE_REPO_PATH));
+    assertThrows(IllegalArgumentException.class,
+        () -> testee.deleteIndexedUrl("/foo", SAMPLE_URL, ""));
+  }
+
+  private void testSuccessfulResponse(IndexUpdateResponse response) {
+    assertThat(response, instanceOf(IndexUpdateResponse.class));
+    assertThat(response.getUrl(), is(SAMPLE_URL));
+    assertThat(response.getMessage(), is("Added URL to queue of site"));
+    assertThat(response.getSiteId(), is("1"));
+
+  }
+
+  private JsonObject getSuccessResponse() {
+    return new JsonParser().parse(
+            new InputStreamReader(getClass().getResourceAsStream("/__files/search/indexupdate/success.json")))
+        .getAsJsonObject();
+  }
+
+  private DefaultIndexContentPayload getCompleteDefaultIndexContentPayload() {
+    return DefaultIndexContentPayload.builder()
+        .content("foo")
+        .title("bar")
+        .url("baz")
+        .repositoryPath("baz")
+        .language("de")
+        .metaKeywords("foo bar")
+        .metaDescription("bar")
+        .scope("qux")
+        .build();
+  }
+}
+

--- a/core/src/test/java/com/valtech/aem/saas/core/query/QueryStringConstructorTest.java
+++ b/core/src/test/java/com/valtech/aem/saas/core/query/QueryStringConstructorTest.java
@@ -1,21 +1,21 @@
 package com.valtech.aem.saas.core.query;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
 import java.util.Arrays;
-import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Test;
 
 class QueryStringConstructorTest {
 
   @Test
   void testGetQueryString() {
-    MatcherAssert.assertThat(GetQueryStringConstructor.builder()
+    assertThat(GetQueryStringConstructor.builder()
             .query(new DefaultTermQuery("foo"))
             .build().getQueryString(),
         is("?term=foo"));
 
-    MatcherAssert.assertThat(GetQueryStringConstructor.builder()
+    assertThat(GetQueryStringConstructor.builder()
             .query(new DefaultTermQuery("foo"))
             .queries(Arrays.asList(new PaginationQuery(1, 100, 1000),
                 FiltersQuery.builder().filterEntry("bar", "/foo/baz").build()))

--- a/core/src/test/resources/__files/search/indexupdate/success.json
+++ b/core/src/test/resources/__files/search/indexupdate/success.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://wknd.site/us/en/adventures/bali-surf-camp.html",
+  "site.id": 1,
+  "message": "Added URL to queue of site",
+  "id": "any_http://only.to.test/if/it/works"
+}


### PR DESCRIPTION
 - add Search client config in Sling CA configs
 - define index update payload, response interfaces
  - create default implementation respectively
 - implement the index update service with 2 actions:
  - index trigger add
  - index trigger delete
  - index content
 - create unit tests
 - update definition SearchRequest and implementation of SearchRequestExecutorService
  - handle response success per request (customize what response code is considered successful)
  - create unit tests for all SearchRequest implementations
 - create a HttpDeleteWithBody by extending org.apache.http.client.methods.HttpEntityEnclosingRequestBase (utilized in SearchRequestDelete for IndexUpdateService::deleteIndexedUrl)
 - update SearchRequestPost to accept HttpEntity instead of list of NameValuePair objects. (makes it more flexible, to accept different request payload types)