### PR TITLE
feat(ICSAAS-380): add restore suggestions feature

### DIFF
--- a/ui.frontend/src/main/webpack/site/js/components/searchInput.ts
+++ b/ui.frontend/src/main/webpack/site/js/components/searchInput.ts
@@ -53,7 +53,7 @@ const buildSuggestionElements = ({
   searchContainer,
   suggestionDropdown,
 }: {
-  results: String[]
+  results: string[]
   regexp: RegExp
   query: string
   searchInput: HTMLInputElement
@@ -62,10 +62,9 @@ const buildSuggestionElements = ({
 }): void => {
   const searchButtonElement = document.getElementsByClassName(
     'saas-container_button',
-  )?.[0] as HTMLButtonElement
+  )?.[0] as HTMLButtonElement | undefined
   results.forEach((result) => {
-    const resultString = result as string
-    const cleanAndFormatResult = cleanString(resultString).replace(
+    const cleanAndFormatResult = cleanString(result).replace(
       regexp,
       `<b>${query}</b>`,
     )
@@ -78,7 +77,7 @@ const buildSuggestionElements = ({
       cleanSessionStorage()
       removeSuggestionList(searchContainer)
 
-      searchInputElementCopy.value = resultString
+      searchInputElementCopy.value = result
 
       if (searchButtonElement) {
         searchButtonElement.click()

--- a/ui.frontend/src/main/webpack/site/js/components/searchInput.ts
+++ b/ui.frontend/src/main/webpack/site/js/components/searchInput.ts
@@ -1,6 +1,11 @@
 import cleanString from '../utils/cleanString'
 import debounce from '../utils/debounce'
 import fetchAutoComplete from '../utils/fetchAutoComplete'
+import {
+  cleanSessionStorage,
+  STORAGE_QUERY_STRING_KEY,
+  STORAGE_SUGGESTIONS_KEY,
+} from '../utils/sessionStorage'
 
 type SearchInputOptions = {
   id: string
@@ -10,7 +15,8 @@ type SearchInputOptions = {
   autoSuggestionDebounceTime: number
   searchContainer: HTMLDivElement
 }
-
+const SUGGESTION_DROPDOWN_ID = 'suggestions'
+const SEARCH_INPUT_CLASS = 'search-input'
 const SAAS_CONTAINER_FORM_SUGGESTIONS_CLASS =
   '.saas-container_form #suggestions'
 const SUGGESTION_ELEMENT_CLASS = 'saas-suggestions-element'
@@ -39,6 +45,60 @@ const removeSuggestionList = (searchContainer: HTMLDivElement) => {
   }
 }
 
+const buildSuggestionElements = ({
+  results,
+  regexp,
+  query,
+  searchInput,
+  searchContainer,
+  suggestionDropdown,
+}: {
+  results: String[]
+  regexp: RegExp
+  query: string
+  searchInput: HTMLInputElement
+  searchContainer: HTMLDivElement
+  suggestionDropdown: Element
+}): void => {
+  const searchButtonElement = document.getElementsByClassName(
+    'saas-container_button',
+  )?.[0] as HTMLButtonElement
+  results.forEach((result) => {
+    const resultString = result as string
+    const cleanAndFormatResult = cleanString(resultString).replace(
+      regexp,
+      `<b>${query}</b>`,
+    )
+    const suggestionDropdownElement = document.createElement('div')
+    suggestionDropdownElement.innerHTML = cleanAndFormatResult
+    suggestionDropdownElement.classList.add(SUGGESTION_ELEMENT_CLASS)
+
+    suggestionDropdownElement.addEventListener('click', () => {
+      const searchInputElementCopy = searchInput
+      cleanSessionStorage()
+      removeSuggestionList(searchContainer)
+
+      searchInputElementCopy.value = resultString
+
+      if (searchButtonElement) {
+        searchButtonElement.click()
+      }
+    })
+
+    suggestionDropdown.appendChild(suggestionDropdownElement)
+  })
+  searchInput.after(suggestionDropdown)
+}
+
+const getCleanedQueryAndRegex = (
+  query: string,
+): { cleanedQuery: string; regexp: RegExp } => {
+  const cleanedQuery = cleanString(query)
+  const regexp = new RegExp(cleanedQuery, 'gi')
+
+  return { cleanedQuery, regexp }
+}
+
 const debouncedSearch = (autoSuggestionDebounceTime: number) =>
   debounce(
     async (
@@ -52,23 +112,22 @@ const debouncedSearch = (autoSuggestionDebounceTime: number) =>
 
       if (!query?.length || query.length < autocompleteTriggerThreshold) {
         removeSuggestionList(searchContainer)
+        cleanSessionStorage()
       }
 
       if (query.length >= autocompleteTriggerThreshold) {
-        const cleanedQuery = cleanString(query)
-        const regexp = new RegExp(cleanedQuery, 'gi')
-        const searchButtonElement = document.getElementsByClassName(
-          'saas-container_button',
-        )?.[0] as HTMLElement
+        const { cleanedQuery, regexp } = getCleanedQueryAndRegex(query)
         const results = await fetchAutoComplete(autocompleteUrl, cleanedQuery)
         const existingSuggestions = searchContainer.querySelector(
           SAAS_CONTAINER_FORM_SUGGESTIONS_CLASS,
         )
         let suggestionDropdown: Element | null = null
 
+        sessionStorage.setItem(STORAGE_QUERY_STRING_KEY, query)
+
         if (!existingSuggestions) {
           suggestionDropdown = document.createElement('div')
-          suggestionDropdown.id = 'suggestions'
+          suggestionDropdown.id = SUGGESTION_DROPDOWN_ID
         } else {
           suggestionDropdown = existingSuggestions
         }
@@ -76,31 +135,19 @@ const debouncedSearch = (autoSuggestionDebounceTime: number) =>
         suggestionDropdown.innerHTML = ''
 
         if (results?.length) {
-          results.forEach((result) => {
-            const cleanAndFormatResult = cleanString(result).replace(
-              regexp,
-              `<b>${query}</b>`,
-            )
-            const suggestionDropdownElement = document.createElement('div')
-            suggestionDropdownElement.innerHTML = cleanAndFormatResult
-            suggestionDropdownElement.classList.add(SUGGESTION_ELEMENT_CLASS)
+          sessionStorage.setItem(
+            STORAGE_SUGGESTIONS_KEY,
+            JSON.stringify(results),
+          )
 
-            suggestionDropdownElement.addEventListener('click', () => {
-              const searchInputElementCopy = searchInput
-
-              removeSuggestionList(searchContainer)
-
-              searchInputElementCopy.value = result
-
-              if (searchButtonElement) {
-                searchButtonElement.click()
-              }
-            })
-
-            suggestionDropdown.appendChild(suggestionDropdownElement)
+          buildSuggestionElements({
+            results,
+            regexp,
+            query,
+            searchInput,
+            searchContainer,
+            suggestionDropdown,
           })
-
-          searchInput.after(suggestionDropdown)
         }
       }
     },
@@ -116,6 +163,7 @@ const buildSearchInput = ({
   searchContainer,
 }: SearchInputOptions): HTMLInputElement => {
   const searchInput = document.createElement('input')
+  searchInput.classList.add(SEARCH_INPUT_CLASS)
 
   searchInput.placeholder = searchFieldPlaceholderText
   searchInput.id = id
@@ -123,6 +171,26 @@ const buildSearchInput = ({
   setSaasCurrentFocusSuggestion(searchInput, -1)
 
   const search = debouncedSearch(autoSuggestionDebounceTime)
+
+  searchInput.addEventListener('focus', () => {
+    const query = sessionStorage.getItem(STORAGE_QUERY_STRING_KEY) || ''
+    const results: String[] = JSON.parse(
+      sessionStorage.getItem(STORAGE_SUGGESTIONS_KEY) || '[]',
+    )
+    const { regexp } = getCleanedQueryAndRegex(query)
+
+    const suggestionDropdown = document.createElement('div')
+    suggestionDropdown.id = SUGGESTION_DROPDOWN_ID
+
+    buildSuggestionElements({
+      results,
+      regexp,
+      query,
+      searchInput,
+      searchContainer,
+      suggestionDropdown,
+    })
+  })
 
   searchInput.addEventListener('input', (event) => {
     search(
@@ -134,9 +202,13 @@ const buildSearchInput = ({
     )
   })
 
-  document.addEventListener('click', () => {
-    /* Remove the autocomplete list from DOM when a click happens in the document */
-    removeSuggestionList(searchContainer)
+  document.addEventListener('click', (event) => {
+    /* Remove the autocomplete list from DOM when a click happens in the document, except if it is on the search input element */
+    if (
+      !(event.target as HTMLInputElement).classList.contains(SEARCH_INPUT_CLASS)
+    ) {
+      removeSuggestionList(searchContainer)
+    }
   })
 
   searchInput.addEventListener('keydown', (e) => {

--- a/ui.frontend/src/main/webpack/site/js/initSearch.ts
+++ b/ui.frontend/src/main/webpack/site/js/initSearch.ts
@@ -1,9 +1,11 @@
 import { buildSearch } from './buildSearch'
 import { getSearchElements } from './searchElement'
+import { cleanSessionStorage } from './utils/sessionStorage'
 
 function initSearch(): void {
   window.addEventListener('load', () => {
     const searchElements = getSearchElements()
+    cleanSessionStorage()
 
     if (!searchElements) {
       return

--- a/ui.frontend/src/main/webpack/site/js/utils/sessionStorage.ts
+++ b/ui.frontend/src/main/webpack/site/js/utils/sessionStorage.ts
@@ -1,0 +1,10 @@
+export const STORAGE_SUGGESTIONS_KEY = '__saas__suggestions__'
+export const STORAGE_QUERY_STRING_KEY = '__saas__queryString__'
+
+export const cleanSessionStorage = (
+  sessionStorageKeys = [STORAGE_SUGGESTIONS_KEY, STORAGE_QUERY_STRING_KEY],
+): void => {
+  sessionStorageKeys?.forEach((storageKey: string) =>
+    sessionStorage.removeItem(storageKey),
+  )
+}


### PR DESCRIPTION
## Why?
Each time the suggestions were gone (clicking somewhere on the page), I had to type in again in order to fetch (perform a request) them back. Not the best UX :-)

- suggestions won't be removed when the click occurs on the search input element
- save and restore suggestions into/from the session storage (will be deleted once the browser is closed and we save a request to backend)

### localhost:4502 is the current behavior and localhost:8080 is with the improvement

https://user-images.githubusercontent.com/81755864/151024016-53e1dc24-af33-4647-907a-30f6019e514a.mov


