### PR TITLE
fix(ICSAAS-380): reset suggestions storage before saving new results

### DIFF
--- a/ui.frontend/src/main/webpack/site/js/components/searchInput.ts
+++ b/ui.frontend/src/main/webpack/site/js/components/searchInput.ts
@@ -131,6 +131,7 @@ const debouncedSearch = (autoSuggestionDebounceTime: number) =>
           suggestionDropdown = existingSuggestions
         }
 
+        cleanSessionStorage([STORAGE_SUGGESTIONS_KEY])
         suggestionDropdown.innerHTML = ''
 
         if (results?.length) {


### PR DESCRIPTION
## How to reproduce?

- type in 'wknd'
- you get some results which are saved into the session storage
- type in 'wknd xxx' (without deleting what type before, just add 'xxx')
- the restored suggestions are from the previous search. In this case, it should be empty as no result.

The fix is to always re-initialize the session storage 'suggestions'. We keep the query string though.