### PR TITLE
fix(webpack): remove devtool option as already defined in config

### DIFF
--- a/ui.frontend/package.json
+++ b/ui.frontend/package.json
@@ -13,7 +13,7 @@
   "main": "package/saas.js",
   "license": "SEE LICENSE IN LICENSE.txt",
   "scripts": {
-    "dev": "webpack -d --env dev --config ./webpack.dev.js && clientlib --verbose",
+    "dev": "webpack --env dev --config ./webpack.dev.js && clientlib --verbose",
     "prod": "webpack --config ./webpack.prod.js && clientlib --verbose",
     "start": "webpack-dev-server --open --config ./webpack.dev.js",
     "sync": "aemsync -d -p ../ui.apps/src/main/content",


### PR DESCRIPTION
Running `npm run dev` breaks because no values are passed to the -d (devtool) option. Plus, we already define that in the webpack.dev (line 11 -> devtool: 'inline-source-map'). No need to have it also in the command line.
Maybe it was because of the old version of webpack that was defaulting the value to something.