### PR TITLE
chore(lint): update eslint config following lint error messages

### DIFF
--- a/ui.frontend/.eslintrc.js
+++ b/ui.frontend/.eslintrc.js
@@ -6,10 +6,13 @@ module.exports = {
     '@valtech-ch/eslint-config/rules',
     'plugin:sonarjs/recommended',
   ],
+  parser: '@typescript-eslint/parser',
   parserOptions: {
     ecmaVersion: 2021, // Allows for the parsing of modern ECMAScript features
     sourceType: 'module', // Allows for the use of imports
+    tsconfigRootDir: __dirname,
   },
+  ignorePatterns: ['*.config.js', '.eslintrc.js'],
   rules: {
     'import/no-cycle': 'off',
   },


### PR DESCRIPTION
Even with .eslintignore set, I still had the following in several files and vscode,

```
Parsing error: "parserOptions.project" has been set for @typescript-eslint/parser.
The file does not match your project config
The file must be included in at least one of the projects provided.
```

<img width="603" alt="Capture d’écran 2022-02-08 à 10 57 39" src="https://user-images.githubusercontent.com/81755864/152963425-fc744099-16f5-42eb-b105-c9ab093f16c9.png">

