### PR TITLE
Feature/icsaas 432 clear button

### DIFF
--- a/ui.frontend/src/main/webpack/site/js/buildSearch.ts
+++ b/ui.frontend/src/main/webpack/site/js/buildSearch.ts
@@ -1,3 +1,4 @@
+import { buildSearchClearButton } from './components/buildSearchClearButton'
 import buildSearchButton from './components/searchButton'
 import buildSearchForm, {
   addEventToSearchForm,
@@ -38,6 +39,7 @@ export const buildSearch = async (
   searchContainer.classList.add('cmp-saas')
 
   const searchFormElement = buildSearchForm()
+  const searchResetButton = buildSearchClearButton()
   const searchInputWrapper = document.createElement('div')
   searchInputWrapper.classList.add('cmp-saas__search-input-wrapper')
 
@@ -74,6 +76,8 @@ export const buildSearch = async (
   if (searchButtonElement) {
     searchFormElement.appendChild(searchButtonElement)
   }
+  searchResetButton.classList.add('cmp-saas__search-clear-button--hide')
+  searchInputWrapper.appendChild(searchResetButton)
 
   const searchElementParent = searchElement.parentElement
   searchElementParent?.replaceChild(searchContainer, searchElement)

--- a/ui.frontend/src/main/webpack/site/js/buildSearch.ts
+++ b/ui.frontend/src/main/webpack/site/js/buildSearch.ts
@@ -76,7 +76,7 @@ export const buildSearch = async (
   if (searchButtonElement) {
     searchFormElement.appendChild(searchButtonElement)
   }
-  searchResetButton.classList.add('cmp-saas__search-clear-button--hide')
+  searchResetButton?.classList.add('cmp-saas__search-clear-button--hide')
   searchInputWrapper.appendChild(searchResetButton)
 
   const searchElementParent = searchElement.parentElement
@@ -90,7 +90,7 @@ export const buildSearch = async (
 
   if (searchValue) {
     searchInputElement.value = searchValue
-
+    searchResetButton?.classList.remove('cmp-saas__search-clear-button--hide')
     await triggerSearch(
       searchFormElement,
       searchInputElement,

--- a/ui.frontend/src/main/webpack/site/js/components/buildSearchClearButton.ts
+++ b/ui.frontend/src/main/webpack/site/js/components/buildSearchClearButton.ts
@@ -14,7 +14,7 @@ export const buildSearchClearButton = () => {
       searchInput.value = ''
       searchInput.focus()
       cleanSessionStorage()
-      const suggestionElement = document.getElementById('#cmp-saas-suggestions')
+      const suggestionElement = document.getElementById('cmp-saas-suggestions')
       if (suggestionElement) {
         suggestionElement.remove()
       }

--- a/ui.frontend/src/main/webpack/site/js/components/buildSearchClearButton.ts
+++ b/ui.frontend/src/main/webpack/site/js/components/buildSearchClearButton.ts
@@ -1,0 +1,24 @@
+import { cleanSessionStorage } from '../utils/sessionStorage'
+
+export const buildSearchClearButton = () => {
+  const resetButton = document.createElement('span')
+  resetButton.classList.add('cmp-saas__search-clear-button')
+
+  resetButton.addEventListener('click', () => {
+    const searchInput = document.getElementsByClassName(
+      'cmp-saas__search-input',
+    )?.[0] as HTMLInputElement
+
+    if (searchInput) {
+      searchInput.value = ''
+      searchInput.focus()
+      cleanSessionStorage()
+      const suggestionElement = document.getElementById('#cmp-saas-suggestions')
+      if (suggestionElement) {
+        suggestionElement.remove()
+      }
+    }
+  })
+
+  return resetButton
+}

--- a/ui.frontend/src/main/webpack/site/js/components/buildSearchClearButton.ts
+++ b/ui.frontend/src/main/webpack/site/js/components/buildSearchClearButton.ts
@@ -1,10 +1,11 @@
 import { cleanSessionStorage } from '../utils/sessionStorage'
 
 export const buildSearchClearButton = () => {
-  const resetButton = document.createElement('span')
-  resetButton.classList.add('cmp-saas__search-clear-button')
+  const searchClearButton = document.createElement('span')
+  searchClearButton.classList.add('cmp-saas__search-clear-button')
 
-  resetButton.addEventListener('click', () => {
+  searchClearButton.addEventListener('click', () => {
+    searchClearButton.classList.add('cmp-saas__search-clear-button--hide')
     const searchInput = document.getElementsByClassName(
       'cmp-saas__search-input',
     )?.[0] as HTMLInputElement
@@ -20,5 +21,5 @@ export const buildSearchClearButton = () => {
     }
   })
 
-  return resetButton
+  return searchClearButton
 }

--- a/ui.frontend/src/main/webpack/site/js/components/searchInput.ts
+++ b/ui.frontend/src/main/webpack/site/js/components/searchInput.ts
@@ -218,9 +218,24 @@ const buildSearchInput = ({
   })
 
   searchInput.addEventListener('input', (event) => {
+    const inputValue = (event?.target as HTMLInputElement)?.value
+    const searchClearButton = document.querySelector(
+      '.cmp-saas__search-clear-button',
+    )
+
+    if (searchClearButton) {
+      if (inputValue.length >= autocompleteTriggerThreshold) {
+        searchClearButton.classList.remove(
+          'cmp-saas__search-clear-button--hide',
+        )
+      } else {
+        searchClearButton.classList.add('cmp-saas__search-clear-button--hide')
+      }
+    }
+
     search(
       autocompleteUrl,
-      (event?.target as HTMLInputElement)?.value,
+      inputValue,
       autocompleteTriggerThreshold,
       searchInput,
       searchContainer,

--- a/ui.frontend/src/main/webpack/site/js/components/searchInput.ts
+++ b/ui.frontend/src/main/webpack/site/js/components/searchInput.ts
@@ -222,16 +222,9 @@ const buildSearchInput = ({
     const searchClearButton = document.querySelector(
       '.cmp-saas__search-clear-button',
     )
-
-    if (searchClearButton) {
-      if (inputValue.length >= autocompleteTriggerThreshold) {
-        searchClearButton.classList.remove(
-          'cmp-saas__search-clear-button--hide',
-        )
-      } else {
-        searchClearButton.classList.add('cmp-saas__search-clear-button--hide')
-      }
-    }
+    const action =
+      inputValue.length >= autocompleteTriggerThreshold ? 'remove' : 'add'
+    searchClearButton?.classList[action]('cmp-saas__search-clear-button--hide')
 
     search(
       autocompleteUrl,

--- a/ui.frontend/src/main/webpack/site/styles/wkndsample/README.md
+++ b/ui.frontend/src/main/webpack/site/styles/wkndsample/README.md
@@ -63,11 +63,12 @@ Below are all the classes that are used in the SAAS module and can be styled.
 .cmp-saas__tab {}
 ```
 
-### Search and load more buttons
+### Search, load more and reset buttons
 
 ```
 .cmp-saas__button {}
 .cmp-saas__load-more-button {}
+.cmp-saas__search-clear-button {}
 ```
 
 ### Autosuggest

--- a/ui.frontend/src/main/webpack/site/styles/wkndsample/wkndsample.scss
+++ b/ui.frontend/src/main/webpack/site/styles/wkndsample/wkndsample.scss
@@ -315,9 +315,6 @@ $search-clear-button-sizes: 20px;
   z-index: 1;
   opacity: 0.8;
   cursor: pointer;
-  .search-redirect & {
-    display: none;
-  }
 }
 .cmp-saas__search-clear-button:hover,
 .cmp-saas__search-clear-button:focus {

--- a/ui.frontend/src/main/webpack/site/styles/wkndsample/wkndsample.scss
+++ b/ui.frontend/src/main/webpack/site/styles/wkndsample/wkndsample.scss
@@ -4,6 +4,8 @@
 @import './spacing';
 @import './animation';
 
+$search-clear-button-sizes: 20px;
+
 .search {
   * {
     font-family: $typography-font;
@@ -301,4 +303,41 @@
       float: left;
     }
   }
+}
+
+.cmp-saas__search-clear-button {
+  position: absolute;
+  right: spacing(5);
+  top: 50%;
+  width: $search-clear-button-sizes;
+  height: $search-clear-button-sizes;
+  transform: translateY(-50%);
+  z-index: 1;
+  opacity: 0.8;
+  cursor: pointer;
+  .search-redirect & {
+    display: none;
+  }
+}
+.cmp-saas__search-clear-button:hover,
+.cmp-saas__search-clear-button:focus {
+  opacity: 1;
+}
+.cmp-saas__search-clear-button:before,
+.cmp-saas__search-clear-button:after {
+  position: absolute;
+  left: spacing(3);
+  content: ' ';
+  height: $search-clear-button-sizes;
+  width: 2px;
+  background-color: $color-5;
+}
+.cmp-saas__search-clear-button:before {
+  transform: rotate(45deg);
+}
+.cmp-saas__search-clear-button:after {
+  transform: rotate(-45deg);
+}
+.cmp-saas__search-clear-button--hide {
+  display: none;
 }


### PR DESCRIPTION
- add search clear button
- add show and hide clear button logic. Eg. show if there is a query AND query length is greater than 3 characters (autocompleteTriggerThreshold)
- logic works also on page reload

For now, only display for the search and hidden for the search redirect. @nhirrle @igorsimovski I can put it back though.
UPDATE: actually as Filip mentioned, since we display the clear button only when user types in something...the placeholder text will be gone...I will put it back then.

<img width="200" alt="Capture d’écran 2022-02-14 à 17 40 49" src="https://user-images.githubusercontent.com/81755864/153907102-047ebdcf-7b0f-4f9f-82d2-78d5dbb748af.png">


https://user-images.githubusercontent.com/81755864/153900349-965a9148-1ec7-4177-82f1-49e7914b9292.mov


