### PR TITLE
Bugfix/icsaas 425 fix grid when facet filters long

### DIFF
--- a/ui.frontend/src/main/webpack/site/styles/wkndsample/wkndsample.scss
+++ b/ui.frontend/src/main/webpack/site/styles/wkndsample/wkndsample.scss
@@ -76,7 +76,7 @@
   .cmp-saas__results-items {
     grid-area: resultsItems;
     display: grid;
-    grid-auto-rows: 1fr;
+    grid-auto-rows: max-content;
 
     @media #{$mq-3} {
       grid-template-columns: repeat(2, 50%);

--- a/ui.frontend/src/main/webpack/site/styles/wkndsample/wkndsample.scss
+++ b/ui.frontend/src/main/webpack/site/styles/wkndsample/wkndsample.scss
@@ -91,7 +91,7 @@
     box-shadow: 0 0 0 1px $color-1;
     border-radius: 4px;
     transition: 0.08s ease-in;
-    min-height: 200px;
+    min-height: 320px;
     @media (prefers-color-scheme: dark) {
       background-color: $color-2;
     }


### PR DESCRIPTION
- increase default min-height for long text
- use the content to set the height of each result item (currently the issue is that the height of the items is set based on the grid available space. This space is affected by the length of the facet group list which expands that space)

This is only a work around and as long as no item has content more than 320px height (5-6 lines of text), we will be fine. The best would be to set a definitive height and cut the text (ellipsis, shade...), so all items really fit.

Increasing the default min-height and using the item content (I added a lot of facet filters to see that it won't affect the height anymore). It may just looks like there is a lot of space to fill in ;-) though.

If I don't set the default min-height, we may get a row with longer items than others. 

Anyway, just to say, that is the "most okayish" work around I could come up with for this week. I can create a task, so to not forget.

<img width="1442" alt="Capture d’écran 2022-02-14 à 18 22 38" src="https://user-images.githubusercontent.com/81755864/153914359-aaf1a175-409c-4a4f-9be8-c5ce63d21631.png">
