### PR TITLE
docs: fix links in ui.frontend/README.md to contain full urls.

### DIFF
--- a/ui.frontend/README.md
+++ b/ui.frontend/README.md
@@ -1,12 +1,12 @@
 # Frontend Library of the AEM Module to integrate Valtech's Search as a Service
 
-This is the frontend library of the [AEM Module to integrate Valtech's Search as a Service](../README.md).
+This is the frontend library of the [AEM Module to integrate Valtech's Search as a Service](https://github.com/valtech-ch/saas-aem-module/blob/main/README.md).
 More info about the project can be also found there.
 
 ## Integration
 
 The frontend sources can be either embedded with clientlibs or added as a dependency in your frontend build.
-To use with clientlibs, please see the details outlined [here](../README.md#clientlibs).
+To use with clientlibs, please see the details outlined [here](https://github.com/valtech-ch/saas-aem-module/blob/main/README.md#clientlibs).
 
 ## Build and release procedure
 

--- a/ui.frontend/package.json
+++ b/ui.frontend/package.json
@@ -4,7 +4,8 @@
   "description": "Frontend of the Valtech CH Search as a Service module",
   "repository": {
     "type": "git",
-    "url": "https://github.com/valtech-ch/saas-aem-module"
+    "url": "https://github.com/valtech-ch/saas-aem-module",
+    "directory": "ui.frontend"
   },
   "author": {
     "name": "Valtech Switzerland AG",


### PR DESCRIPTION
There is an open bug https://github.com/npm/marky-markdown/issues/449 which suggests this workaround.
On top of that I changed the package.json to represent that we are here in a monorepo