### PR TITLE
ICSAAS-483: Allow Context filters disabling and language override

### DIFF
--- a/api/src/main/java/com/valtech/aem/saas/api/autocomplete/AutocompleteService.java
+++ b/api/src/main/java/com/valtech/aem/saas/api/autocomplete/AutocompleteService.java
@@ -21,10 +21,28 @@ public interface AutocompleteService {
      * @param filters             search filters
      * @return List of string represented autocomplete options. Empty list if no options are found.
      */
-    List<String> getResults(
+    default List<String> getResults(
             @NonNull SearchCAConfigurationModel searchConfiguration,
             @NonNull String text,
             @NonNull String language,
-            Set<Filter> filters);
+            Set<Filter> filters){
+        return getResults(searchConfiguration, text, language, filters, false);
+    }
 
+    /**
+     * Retrieves typeahead (autocomplete) results
+     *
+     * @param searchConfiguration sling model accessing context aware search configurations (i.e client and index).
+     * @param text                search term.
+     * @param language            search language scope.
+     * @param filters             search filters
+     * @param disableContextFilters flag to disable the filters configured in context aware configuration.
+     * @return List of string represented autocomplete options. Empty list if no options are found.
+     */
+    List<String> getResults(
+        @NonNull SearchCAConfigurationModel searchConfiguration,
+        @NonNull String text,
+        @NonNull String language,
+        Set<Filter> filters,
+        boolean disableContextFilters);
 }

--- a/api/src/main/java/com/valtech/aem/saas/api/fulltextsearch/FulltextSearchService.java
+++ b/api/src/main/java/com/valtech/aem/saas/api/fulltextsearch/FulltextSearchService.java
@@ -139,4 +139,26 @@ public interface FulltextSearchService {
             Set<String> facets,
             String template);
 
+    /**
+     * @param searchConfiguration   sling model accessing context aware search configurations (i.e client and index).
+     * @param searchText            full text query value.
+     * @param language              full text search language scope.
+     * @param start                 the start page for search results.
+     * @param rows                  the number of results per page
+     * @param filters               additional filters of type SimpleFilter or CompositeFilter
+     * @param facets                list of field names.
+     * @param disableContextFilters flag to disable the filters configured in context aware configuration.
+     * @return search results object
+     */
+    @SuppressWarnings("java:S107")
+    Optional<FulltextSearchResultsDTO> getResults(
+        @NonNull SearchCAConfigurationModel searchConfiguration,
+        String searchText,
+        @NonNull String language,
+        int start,
+        int rows,
+        Set<Filter> filters,
+        Set<String> facets,
+        boolean disableContextFilters,
+        String template);
 }

--- a/api/src/main/java/com/valtech/aem/saas/api/fulltextsearch/SearchModel.java
+++ b/api/src/main/java/com/valtech/aem/saas/api/fulltextsearch/SearchModel.java
@@ -83,4 +83,12 @@ public interface SearchModel extends SearchInputModel {
         return null;
     }
 
+    /**
+     * Flag to determine whether the filters from context aware configuration should be used for searching.
+     *
+     * @return disable context filters flag.
+     */
+    default boolean isDisableContextFilters(){
+        return false;
+    }
 }

--- a/core/src/main/java/com/valtech/aem/saas/core/autocomplete/AutocompleteServlet.java
+++ b/core/src/main/java/com/valtech/aem/saas/core/autocomplete/AutocompleteServlet.java
@@ -54,7 +54,8 @@ public class AutocompleteServlet extends SlingSafeMethodsServlet {
         List<String> results = autocompleteService.getResults(searchCAConfigurationModel,
                                                               searchTerm,
                                                               searchModel.getLanguage(),
-                                                              searchModel.getFilters());
+                                                              searchModel.getFilters(),
+                                                              searchModel.isDisableContextFilters());
         new JsonResponseCommitter(response).flush(printWriter -> new Gson().toJson(results, printWriter));
     }
 

--- a/core/src/main/java/com/valtech/aem/saas/core/fulltextsearch/SearchModelImpl.java
+++ b/core/src/main/java/com/valtech/aem/saas/core/fulltextsearch/SearchModelImpl.java
@@ -123,6 +123,11 @@ public class SearchModelImpl implements SearchModel, ContainerExporter {
     @Getter
     private Set<Filter> filters;
 
+    @JsonIgnore
+    @Getter
+    @ValueMapValue
+    private boolean disableContextFilters;
+    
     @ChildResource(name = "filters")
     private List<FilterConfigurationModel> configuredFilters;
 

--- a/core/src/main/java/com/valtech/aem/saas/core/fulltextsearch/SearchTabModelImpl.java
+++ b/core/src/main/java/com/valtech/aem/saas/core/fulltextsearch/SearchTabModelImpl.java
@@ -95,6 +95,12 @@ public class SearchTabModelImpl implements SearchTabModel, ComponentExporter {
     @ChildResource(name = "filters")
     private List<FilterConfigurationModel> configuredFilters;
 
+    @ValueMapValue
+    private String language;
+    
+    @ValueMapValue
+    private boolean disableContextFilters;
+
     @ChildResource
     private List<FacetModel> facets;
 
@@ -210,13 +216,14 @@ public class SearchTabModelImpl implements SearchTabModel, ComponentExporter {
         return fulltextSearchService.getResults(
                 searchCAConfigurationModel,
                 searchTerm,
-                requestWrapper.getLocale().getLanguage(),
+                StringUtils.defaultIfBlank(language, parentSearch.getLanguage()),
                 resolveStartOffset(),
                 resultsPerPage,
                 getEffectiveFilters(parentSearch, requestWrapper),
                 Optional.ofNullable(facets).map(List::stream).orElse(
                         Stream.empty()).map(FacetModel::getFieldName).collect(
                         Collectors.toCollection(LinkedHashSet::new)),
+                disableContextFilters || parentSearch.isDisableContextFilters(),
                 template);
     }
 

--- a/core/src/test/java/com/valtech/aem/saas/core/autocomplete/AutocompleteServletTest.java
+++ b/core/src/test/java/com/valtech/aem/saas/core/autocomplete/AutocompleteServletTest.java
@@ -71,7 +71,7 @@ class AutocompleteServletTest {
         SlingHttpServletResponse response = context.response();
         assertThrows(IllegalArgumentException.class, () -> testee.doGet(request, response));
         verify(autocompleteService, never()).getResults(any(SearchCAConfigurationModel.class), anyString(), anyString(),
-                                                        any());
+                                                        any(), anyBoolean());
     }
 
 
@@ -88,6 +88,7 @@ class AutocompleteServletTest {
         verify(autocompleteService, times(1)).getResults(any(SearchCAConfigurationModel.class),
                                                          anyString(),
                                                          anyString(),
-                                                         any());
+                                                         any(), 
+                                                         anyBoolean());
     }
 }

--- a/core/src/test/java/com/valtech/aem/saas/core/fulltextsearch/SearchTabModelImplTest.java
+++ b/core/src/test/java/com/valtech/aem/saas/core/fulltextsearch/SearchTabModelImplTest.java
@@ -92,7 +92,7 @@ class SearchTabModelImplTest {
         testAdaptable();
         verify(fulltextSearchService).getResults(any(SearchCAConfigurationModel.class), anyString(), anyString(),
                                                  startParam.capture(), anyInt(), anySet(), facetInput.capture(),
-                                                 any());
+                                                 anyBoolean(), any());
         assertThat(testee.getResults(), nullValue());
         assertThat(testee.getResultsTotal(), is(0));
         assertThat(testee.getSuggestion(), is(nullValue()));

--- a/ui.apps/src/main/content/jcr_root/apps/saas-aem-module/components/searchtab/_cq_dialog.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/saas-aem-module/components/searchtab/_cq_dialog.xml
@@ -35,6 +35,12 @@
                                                 fieldLabel="Title"
                                                 name="./title"
                                                 required="{Boolean}true"/>
+                                            <language
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                                fieldLabel="Language"
+                                                fieldDescription="Optional override of context resolved language."
+                                                name="./language"/>
                                             <facets
                                                 jcr:primaryType="nt:unstructured"
                                                 fieldLabel="Facets"

--- a/ui.apps/src/main/content/jcr_root/apps/saas-aem-module/shared/dialog/filters.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/saas-aem-module/shared/dialog/filters.xml
@@ -53,6 +53,14 @@
                                 </items>
                             </field>
                         </filters>
+                        <disableContextFilters
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                            text="Disable context filters"
+                            fieldDescription="If checked, the filters configured in the context aware configuration will be disabled, and only the filters configured on the component level will be used"
+                            name="./disableContextFilters"
+                            value="{Boolean}true">
+                        </disableContextFilters>
                     </items>
                 </column>
             </items>


### PR DESCRIPTION
- added language field in search tab dialog
- fixed bug that overriden language was not taken from search component
- allowing to override language from search and search tab components
- added flag to disable the context filters in both search and search tab components
- extended Services for full text search and autocomplete to not use context filters when the the disable context filters checkbox is ticked