### PR TITLE
build: bump Node to 24.16.0 LTS (npm 11.13.0)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,8 +193,8 @@
                     <artifactId>frontend-maven-plugin</artifactId>
                     <version>${frontend-maven-plugin.version}</version>
                     <configuration>
-                        <nodeVersion>v18.16.1</nodeVersion>
-                        <npmVersion>9.5.1</npmVersion>
+                        <nodeVersion>v24.16.0</nodeVersion>
+                        <npmVersion>11.13.0</npmVersion>
                     </configuration>
                     <executions>
                         <execution>


### PR DESCRIPTION
Bumps the frontend-maven-plugin pinned Node from v18.16.1 to v24.16.0 (current Node 24 'Krypton' LTS) and npm from 9.5.1 to 11.13.0.

Reason: several open Dependabot PRs fail CI because dev-dependencies (e.g. yargs-parser@22) now require Node >= 20. This unblocks them.

Scope: build tooling only; no runtime/application code changes.