### PR TITLE
ci: monthly Dependabot schedule + auto-merge for minor/patch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,55 @@
+version: 2
+updates:
+  # Maven dependencies (parent + all modules)
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Zurich"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "java"
+    groups:
+      maven-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Frontend npm dependencies
+  - package-ecosystem: "npm"
+    directory: "/ui.frontend"
+    schedule:
+      interval: "monthly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Zurich"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "javascript"
+    groups:
+      npm-dev-minor-patch:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+      npm-prod-minor-patch:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # GitHub Actions used by the workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Zurich"
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,43 @@
+name: Dependabot auto-merge
+
+# Automatically enables auto-merge for Dependabot version-update PRs that are
+# safe (minor/patch updates). The PR is only merged once the required
+# "Build maven" status check from build.yml passes.
+#
+# Repository prerequisites (configure once in repo settings):
+#   - Settings > General > "Allow auto-merge" must be enabled.
+#   - Settings > Branches: a branch protection rule on `main` requiring the
+#     "Build maven" status check, otherwise --auto merges immediately.
+#   - Settings > Code security: "Allow GitHub Actions to create and approve
+#     pull requests" should be enabled so this workflow can approve.
+
+on:
+  pull_request_target:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Approve and enable auto-merge for minor/patch updates
+        if: >-
+          steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds two pieces of automation:

1. **.github/dependabot.yml** - monthly version updates (Mon 06:00 Europe/Zurich) for Maven (root), npm (ui.frontend), and GitHub Actions, with minor/patch grouped to reduce PR noise.
2. **.github/workflows/dependabot-auto-merge.yml** - approves and enables auto-merge (squash) for Dependabot minor/patch PRs; merge only completes after the required 'Build maven' check passes.

**Repo settings required (one-time):**
- Enable 'Allow auto-merge' (Settings > General).
- Branch protection on main requiring the 'Build maven' check.
- Enable 'Allow GitHub Actions to create and approve pull requests'.