### PR TITLE
ci: ignore major-version Dependabot updates (Adobe/AEM constraints)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,12 @@ updates:
     labels:
       - "dependencies"
       - "java"
+    # Stay on the current major lines: AEM / Adobe platform pins us to older
+    # major versions, so never propose major-version bumps automatically.
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
     groups:
       maven-minor-patch:
         update-types:
@@ -30,6 +36,12 @@ updates:
     labels:
       - "dependencies"
       - "javascript"
+    # Major front-end bumps (e.g. TypeScript 6, style-loader 4) break the AEM
+    # clientlib build, so restrict automated updates to minor/patch only.
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
     groups:
       npm-dev-minor-patch:
         dependency-type: "development"
@@ -53,3 +65,8 @@ updates:
     labels:
       - "dependencies"
       - "github-actions"
+    # Pin to current action majors; review major action upgrades manually.
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"


### PR DESCRIPTION
Adds ignore rules so Dependabot only proposes minor/patch updates across Maven, npm (ui.frontend), and GitHub Actions.

Reason: the AEM / Adobe platform pins us to older major versions (uber-jar, Sling, etc.); major bumps like TypeScript 6, Mockito 5, JUnit 6, Sling Models 2, and Actions majors break the build and must be reviewed manually, not automated.

This stops the noise of major-version PRs going forward. Existing open major PRs are being closed separately.